### PR TITLE
data shield document updates

### DIFF
--- a/convert.md
+++ b/convert.md
@@ -208,7 +208,7 @@ A converted application can request a certificate from the Enclave Manager when 
 
 Check out the following example to see how to configure a request to generate an RSA private key and generate the certificate for the key. The key is kept on the root of the application container. If you don't want an ephemeral key or certificate, you can customize the `keyPath` and `certPath` for your apps and store them on a persistent volume.
 
-1. Save the following template as `app.json` and make the required changed to fit your application's certificate requirements.
+2. Save the following template as `app.json` and make the required changed to fit your application's certificate requirements.
 
  ```json
  {
@@ -241,7 +241,7 @@ Check out the following example to see how to configure a request to generate an
  ```
  {: screen}
 
-2. Enter your variables and run the following command to run the converter again with your certificate information and create an application.
+3. Enter your variables and run the following command to run the converter again with your certificate information and create an application.
 
  ```
 curl -H 'Content-Type: application/json' -d @app.json  -H "Authorization: Bearer $em_token" https://enclave-manager.<ingress-domain>/api/v1/apps
@@ -251,7 +251,7 @@ curl -H 'Content-Type: application/json' -d @app.json  -H "Authorization: Bearer
 ## Create a build
 {: #convert-build}
 
-Run the following command to create a build of an applications:
+Run the following command to create a build of an application:
 ```
 curl -H 'Content-Type: application/json' -d '{"app_id": "53fca221-b65f-4deb-ae39-20534a717b06", "docker_version": "1.15.2" }'  -H "Authorization: Bearer $em_token" https://enclave-manager.<ingress-domain>/api/v1/builds/convert-app
 ```
@@ -259,7 +259,7 @@ curl -H 'Content-Type: application/json' -d '{"app_id": "53fca221-b65f-4deb-ae39
 
 where,
 - `app_id` is the response to the POST message to `/apps`
-- `docket_version` is the docker image tag, which will be combined with the `input_image_name` and `output_image_name` specified when the app was created.
+- `docker_version` is the docker image tag, which will be combined with the `input_image_name` and `output_image_name` specified when the app was created.
 {: shortdesc}
 
 ## Whitelisting applications

--- a/deploy.md
+++ b/deploy.md
@@ -79,6 +79,7 @@ Don't have an application to try the service? No problem. We offer several sampl
     ```
     {: screen}
 
+
 3. Update the fields `your-app-sgx` and `your-registry-server` to your app and server.
 
 4. Create the Kubernetes pod.
@@ -88,3 +89,19 @@ Don't have an application to try the service? No problem. We offer several sampl
    ```
   {: codeblock}
 
+## Deploying images on IBM Cloud OpenShift clusters
+
+Data Shield 1.5.xx includes a technology preview of support for IBM Cloud OpenShift clusters.
+
+To deploy on an OpenShift cluster, specify `--set global.OpenShiftEnabled=true`  when installing the helm chart.
+
+Be aware of the following limitations when using {{site.data.keyword.datashield_full}} on OpenShift:
+
+* Currently, application containers must be run as privileged containers so that they may access the host's SGX devices. This requirement will be eliminated in a future release. To make containers privileged, add the following to the pod specification for each container that needs to access the SGX devices:
+```
+securityContext:
+  privileged: true
+```
+OpenShift security policies may restrict creation of privileged containers. Cluster admin users have permission to create privileged containers when creating pods directly. When pods are created by a Kubernetes controller (replica set, daemon set), that controller must be associated with a service account that has permission to create privileged containers.
+
+* Installing {{site.data.keyword.datashield_full}} on a cluster puts SELinux in permissive mode. SELinux compatibility will be addressed in an upcoming release.

--- a/install.md
+++ b/install.md
@@ -123,12 +123,12 @@ To install {{site.data.keyword.datashield_short}} onto your cluster:
   ```
   {: codeblock}
 
-6. Get the information that you need to set up [backup and restore](/docs/services/data-shield?topic=data-shield-backup-restore) capabilities. 
+6. Get the information that you need to set up [backup and restore](/docs/services/data-shield?topic=data-shield-backup-restore) capabilities.
 
-7. Initialize Helm by creating a role binding policy for Tiller. 
+7. Initialize Helm by creating a role binding policy for Tiller.
 
   1. Create a service account for Tiller.
-  
+
     ```
     kubectl --namespace kube-system create serviceaccount tiller
     ```
@@ -156,6 +156,9 @@ To install {{site.data.keyword.datashield_short}} onto your cluster:
   ```
   helm install iks-charts/ibmcloud-data-shield --set enclaveos-chart.Manager.AdminEmail=<admin email> --set enclaveos-chart.Manager.AdminName=<admin name> --set enclaveos-chart.Manager.AdminIBMAccountId=<hex account ID> --set global.IngressDomain=<your cluster's ingress domain>
   ```
+  To deploy {{site.data.keyword.datashield_full}} on an OpenShift cluster, specify ```--set global.OpenShiftEnabled=true``` when installing the helm chart.
+  {: note}
+
   {: codeblock}
 
   <table>
@@ -188,6 +191,3 @@ To install {{site.data.keyword.datashield_short}} onto your cluster:
   kubectl get pods
   ```
   {: codeblock}
-
-
-

--- a/manage.md
+++ b/manage.md
@@ -144,10 +144,9 @@ You can convert, deploy, and whitelist your application all at the same time by 
 
 7. Edit any advanced settings that you might want to change.
 
-8. Click **Create new application**. The application is deployed and added to your whitelist. You can approve the build request in the **tasks** tab.
+8. Add any certificate using the **Certificate configuration** section. A converted application can request a certificate from the {{site.data.keyword.datashield_short}} when your application is started. The certificates are signed by the {{site.data.keyword.datashield_short}} Certificate Authority, which issues certificates only to enclaves presenting a valid attestation.
 
-
-
+9. Click **Create new application**. The application is deployed and added to your whitelist. You can approve the build request in the **tasks** tab.
 
 ### Editing an app
 {: #em-app-edit}
@@ -201,7 +200,7 @@ When an application is whitelisted, it is added to the list of pending requests 
 ## Viewing logs
 {: #em-view}
 
-You can audit your Enclave manager instance for several different types of activity. 
+You can audit your Enclave manager instance for several different types of activity.
 {: shortdesc}
 
 1. Navigate to the **Audit log** tab of the Enclave Manager UI.
@@ -211,7 +210,6 @@ You can audit your Enclave manager instance for several different types of activ
   * User approval: Activity that pertains to a user's access such as their approval or denial to use the account.
   * Node attestation: Activity that pertains to node attestation.
   * Certificate Authority: Activity that pertains to a Certificate Authority.
-  * Administration: Activity that pertains to administrative. 
+  * Administration: Activity that pertains to administrative.
 
 If you want to keep a record of the logs beyond 1 month, you can export the information as a `.csv` file.
-


### PR DESCRIPTION
@smguilia @ChristinaMak - the following updates are made:

- Added content for "**Using Data Shield with OpenShift**" in the "Install" and "deploy files".
- Added sections for "**Create application**" and "**Create Build**" using API.
- Added `-Xdump:none` to the options for OpenJ9/Liberty in the Java settings section of Data Shield.
- Added a line for "Requesting Application Certificate" using Data Shield UI which was missing earlier.
- API related updates: replaced the `POST /tools/converter/convert-app` and `POST /builds` APIs with ` POST /apps` and `POST /builds/convert-app`.
