### PR TITLE
Nr/add app

### DIFF
--- a/install.md
+++ b/install.md
@@ -24,7 +24,7 @@ subcollection: data-shield
 # Installing
 {: #install}
 
-You can install {{site.data.keyword.datashield_full}} on either a {{site.data.keyword.containershort_notm}} or a {{site.data.keyword.openshiftlong_notm}} cluster by using the provided Helm chart. 
+You can install {{site.data.keyword.datashield_full}} on either a {{site.data.keyword.containershort_notm}} or a {{site.data.keyword.openshiftlong_notm}} cluster by using the provided Helm chart.
 {: shortdesc}
 
 **Technology preview**: With {{site.data.keyword.datashield_short}} 1.5, you can preview support for {{site.data.keyword.openshiftlong_notm}} clusters. To deploy on an OpenShift cluster, specify `--set global.OpenShiftEnabled=true`  when you [install the Helm chart](/docs/services/data-shield?topic=data-shield-install).
@@ -60,7 +60,7 @@ For help with downloading the CLIs or configuring your {{site.data.keyword.conta
 
 Before you can work with {{site.data.keyword.datashield_short}}, you must have the following resources.
 
-* An SGX-enabled Kubernetes or OpenShift cluster. Depending on the type of cluster that you choose, the type of machine flavor differs. Be sure that you have the correct corresponding flavor by reviewing the following table. 
+* An SGX-enabled Kubernetes or OpenShift cluster. Depending on the type of cluster that you choose, the type of machine flavor differs. Be sure that you have the correct corresponding flavor by reviewing the following table.
 
   <table>
     <tr>
@@ -77,7 +77,7 @@ Before you can work with {{site.data.keyword.datashield_short}}, you must have t
     </tr>
   </table>
 
-  If you need help with creating your cluster, check out the following resources: 
+  If you need help with creating your cluster, check out the following resources:
 
   1. Prepare to [create your cluster](/docs/containers?topic=containers-clusters#cluster_prepare).
 
@@ -153,7 +153,7 @@ The Helm chart installs the following components:
   ```
   {: codeblock}
 
-6. Get the information that you need to set up [backup and restore](/docs/services/data-shield?topic=data-shield-backup-restore) capabilities. 
+6. Get the information that you need to set up [backup and restore](/docs/services/data-shield?topic=data-shield-backup-restore) capabilities.
 
 7. If you're working with Helm version 2, initialize Helm by creating a role binding policy for Tiller.
 
@@ -161,7 +161,7 @@ The Helm chart installs the following components:
   {: deprecated}
 
   1. Create a service account for Tiller.
-  
+
     ```
     kubectl --namespace kube-system create serviceaccount tiller
     ```
@@ -216,10 +216,12 @@ The Helm chart installs the following components:
     </tr> -->
   </table>
 
+**Note:** Node enrollment and app certificate issuance will now succeed by default on platforms running out of date microcode. If you want these operations to fail on out of date platforms, you can provide the option `--set Manager.FailOnGroupOutOfDate=true` when installing your cluster. It is not possible to change the option on existing clusters.
+{: note}
+
 9. To monitor the startup of your components, you can run the following command.
 
   ```
   kubectl get pods
   ```
   {: codeblock}
-

--- a/manage.md
+++ b/manage.md
@@ -116,7 +116,7 @@ You can convert, deploy, and whitelist your application all at the same time by 
 
 3. Give your application a name and description.
 
-4. Enter the input and output name for your images. The input is the name of your registry and image without the tag. The output is the name of the registry and image where you want to send the converted application.
+4. Enter the input and output name for your images. The input is the name of your registry and image without the docker tag. The docker tag will eventually be added to the builds of this app, by copying from the source build (See Step 4 of "Building applications" section). The output is the name of the registry and image where you want to send the converted application.
 
 5. Enter an **ISVPRDID**. It is a numeric product identifier that you assign to the enclave. You can choose a unique value in range 0 - 65,535.
 
@@ -230,7 +230,7 @@ When an application is whitelisted, it is added to the list of pending requests 
 ## Viewing logs
 {: #em-view}
 
-You can audit your Enclave manager instance for several different types of activity. 
+You can audit your Enclave manager instance for several different types of activity.
 {: shortdesc}
 
 1. Navigate to the **Audit log** tab of the Enclave Manager UI.
@@ -240,11 +240,7 @@ You can audit your Enclave manager instance for several different types of activ
   * User approval: Activity that pertains to a user's access such as their approval or denial to use the account.
   * Node attestation: Activity that pertains to node attestation.
   * Certificate authority: Activity that pertains to a certificate authority.
-  * Administration: Activity that pertains to administration. 
+  * Administration: Activity that pertains to administration.
 
 If you want to keep a record of the logs beyond 1 month, you can export the information as a `.csv` file.
 {: tip}
-
-
-
-

--- a/update.md
+++ b/update.md
@@ -75,7 +75,7 @@ After {{site.data.keyword.datashield_short}} is installed on your cluster, you c
 To update to the newest version with the Helm chart, run the following command.
 
   ```
-  helm upgrade <chart-name> iks-charts/ibmcloud-data-shield --set enclaveos-chart.Manager.AdminEmail=<admin email> --set enclaveos-chart.Manager.AdminName=<admin name> --set enclaveos-chart.Manager.AdminIBMAccountId=<hex account ID> --set global.IngressDomain=<your cluster's ingress domain> 
+  helm upgrade <chart-name> iks-charts/ibmcloud-data-shield --set enclaveos-chart.Manager.AdminEmail=<admin email> --set enclaveos-chart.Manager.AdminName=<admin name> --set enclaveos-chart.Manager.AdminIBMAccountId=<hex account ID> --set global.IngressDomain=<your cluster's ingress domain>
   ```
   {: codeblock}
 
@@ -95,3 +95,5 @@ To update to the newest version with the Helm chart, run the following command.
     </tr>
   </table>
 
+  **Note:** Node enrollment and app certificate issuance will now succeed by default on platforms running out of date microcode. If you want these operations to fail on out of date platforms, you can provide the option `--set Manager.FailOnGroupOutOfDate=true` when installing your cluster. It is not possible to change the option on existing clusters.
+  {: note}


### PR DESCRIPTION
Hi @smguilia,

I have added a note for scenarios with out of date microcode where old clusters, when upgraded to this release, will start accepting out of date attestations. Node enrollment and app certificate issuance will now succeed by default on platforms running out of date microcode. The note also specifies the condition to add for it to fail.

Thanks.