### PR TITLE
migrate helm2 to helm3 steps

### DIFF
--- a/install.md
+++ b/install.md
@@ -1,0 +1,362 @@
+---
+copyright:
+  years: 2018, 2020
+lastupdated: "2020-02-04"
+
+keywords: install data shield, data in use, helm, cluster, environment variable, role binding, bare metal, tls certificates, tiller, ingress, subdomain, docker configuration, sample app, tech preivew, runtime encryption, memory, app security,
+
+subcollection: data-shield
+---
+
+{:external: target="_blank" .external}
+{:shortdesc: .shortdesc}
+{:screen: .screen}
+{:pre: .pre}
+{:table: .aria-labeledby="caption"}
+{:codeblock: .codeblock}
+{:tip: .tip}
+{:note: .note}
+{:important: .important}
+{:deprecated: .deprecated}
+{:download: .download}
+{:preview: .preview}
+
+# Installing
+{: #install}
+
+You can install {{site.data.keyword.datashield_full}} on either a {{site.data.keyword.containershort_notm}} or a {{site.data.keyword.openshiftlong_notm}} cluster by using the provided Helm chart.
+{: shortdesc}
+
+**Technology preview**: With {{site.data.keyword.datashield_short}} 1.5, you can preview support for {{site.data.keyword.openshiftlong_notm}} clusters. To deploy on an {{site.data.keyword.openshiftshort}} cluster, specify `--set global.OpenShiftEnabled=true` when you [install the Helm chart](/docs/data-shield?topic=data-shield-install).
+
+## Before you begin
+{: #install-before}
+
+Before you get started, ensure that you have the following CLIs and plug-ins downloaded.
+
+* [{{site.data.keyword.cloud_notm}} CLI](/docs/cli/reference/ibmcloud?topic=cloud-cli-install-ibmcloud-cli)
+* [{{site.data.keyword.containershort}} and {{site.data.keyword.registryshort_notm}} plug-ins](/docs/cli/reference/ibmcloud?topic=cloud-cli-plug-ins)
+* [Kubernetes](https://kubernetes.io/docs/tasks/tools/install-kubectl/){: external}
+* [Docker](https://docs.docker.com/install/){: external}
+* [Helm version 2](/docs/containers?topic=containers-helm): Be sure to follow the instructions for setting up Helm in a cluster with public access.
+
+  You might want to configure Helm to use `--tls` mode. For help with enabling TLS check out the [Helm repository](https://v2.helm.sh/docs/tiller_ssl/#using-ssl-between-helm-and-tiller){: external}. If you enable TLS, be sure to append `--tls` to every Helm command that you run.
+  {: tip}
+
+
+## Preparing your cluster
+{: #install-prepare-cluster}
+
+To work with {{site.data.keyword.datashield_short}}, you must have an SGX enabled cluster. Depending on whether you're working with Kubernetes or OpenShift, the machine type differs. Be sure that you have the correct machine type by reviewing the following table.
+
+<table>
+  <tr>
+    <th>Type of cluster</th>
+    <th>Available machine types</th>
+  </tr>
+  <tr>
+    <td>{{site.data.keyword.containershort}}</td>
+    <td><code>mb2c.4x32</code> and <code>ms2c.4x32.1.9tb.ssd</code></br>To see the options, you must filter to the <b>Ubuntu 16</b> operating system.</td>
+  </tr>
+  <tr>
+    <td>{{site.data.keyword.openshiftshort}}</td>
+    <td><code>mb3c.4x32</code> and <code>ms3c.4x32.1.9tb.ssd</code></td>
+  </tr>
+</table>
+
+For help with configuring your {{site.data.keyword.containershort_notm}} environment, check out [creating Kubernetes clusters](/docs/containers?topic=containers-cs_cluster_tutorial#cs_cluster_tutorial_lesson1) or [creating OpenShift clusters](/docs/openshift?topic=openshift-openshift_tutorial).
+{: tip}
+
+When you have a running cluster, you can start obtaining the information that you need to install the service. Be sure to save the information that you obtain so that you can use during installation.
+
+1. Log in to the {{site.data.keyword.cloud_notm}} CLI by running the following command and then following the prompts. If you have a federated ID, append the `--sso` option to the end of the command.
+
+  ```
+  ibmcloud login
+  ```
+  {: codeblock}
+
+2. Set the context for your cluster.
+
+  1. Get the command to set the environment variable and download the Kubernetes configuration files.
+
+    ```
+    ibmcloud ks cluster-config <cluster_name_or_ID>
+    ```
+    {: codeblock}
+
+  2. Copy the output beginning with `export` and paste it into your console to set the `KUBECONFIG` environment variable.
+
+3. If you don't know the email that is associated with the administrator or the account ID, run the following command. Make a note of this information.
+
+  ```
+  ibmcloud account show
+  ```
+  {: codeblock}
+
+4. Get the Ingress subdomain for your cluster. Make a note of this information.
+
+  ```
+  ibmcloud ks cluster-get <cluster_name>
+  ```
+  {: codeblock}
+
+
+## Configuring credentials
+{: #install-convert}
+
+Before you can run applications in an Enclave, your container image must be converted. To prepare your image for conversion, create a service ID and give it permissions to work with the container converter.
+
+Not working with IBM Cloud Container Registry? Learn how to [configure credentials for other registries](/docs/data-shield?topic=data-shield-convert#configure-other-registry).
+{: tip}
+
+
+1. Create a service ID and a service ID API key for the {{site.data.keyword.datashield_short}} container converter.
+
+  ```
+  ibmcloud iam service-id-create data-shield-container-converter -d 'Data Shield Container Converter'
+  ```
+  {: codeblock}
+
+2. Create an API key for the container converter.
+
+  ```
+  ibmcloud iam service-api-key-create 'Data Shield Container Converter' data-shield-container-converter
+  ```
+  {: codeblock}
+
+3. Grant the service ID permission to access your container registry.
+
+  ```
+  ibmcloud iam service-policy-create data-shield-container-converter --roles Reader,Writer --service-name container-registry
+  ```
+  {: codeblock}
+
+4. Create a Kubernetes secret to be used for future conversions. Replace the `<api key>` variable, and then run the following command. If you don't have `openssl`, you can use any command-line base64 encoder with appropriate options. Be sure that there are not new lines in the middle or at the end of the encoded string.
+
+  ```
+  (echo -n '{"auths":{"<region>.icr.io":{"auth":"'; echo -n 'iamapikey:<api key>' | openssl base64 -A;  echo '"}}}') | kubectl create secret generic converter-docker-config --from-file=.dockerconfigjson=/dev/stdin
+  ```
+  {: codeblock}
+
+
+
+## Installing Helm and `cert manager`
+{: #install-helm}
+
+To work with {{site.data.keyword.datashield_short}}, you can use Helm version 2 to install the service. The following steps explain how to set up Helm if Tiller is not installed with a service account. If you already have Tiller installed, check out the [Kubernetes Service docs](/docs/containers?topic=containers-helm) for more information.
+
+
+You might want to configure Helm to use `--tls` mode. For help with enabling TLS check out the [Helm repository](https://v2.helm.sh/docs/tiller_ssl/#using-ssl-between-helm-and-tiller){: external}. If you enable TLS, be sure to append `--tls` to every Helm command that you run.
+{: tip}
+
+1. Create a Kubernetes service account and cluster role binding for Tiller in the kube-system namespace of your cluster.
+
+  ```
+  kubectl create serviceaccount tiller -n kube-system
+  ```
+  {: codeblock}
+
+  ```
+  kubectl create clusterrolebinding tiller --clusterrole=cluster-admin --serviceaccount=kube-system:tiller -n kube-system
+  ```
+  {: codeblock}
+
+2. Verify that the Tiller service account is created.
+
+  ```
+  kubectl get serviceaccount -n kube-system tiller
+  ```
+  {: codeblock}
+
+3. Initialize the Helm CLI and install Tiller in your cluster with the service account that you created.
+
+  ```
+  helm init --service-account tiller
+  ```
+  {: codeblock}
+
+4. {{site.data.keyword.datashield_short}} uses [`cert-manager`](https://cert-manager.readthedocs.io/en/latest/){: external} to set up TLS certificates for internal communication between {{site.data.keyword.datashield_short}} services. To work with the service, install an instance of `cert-manager` by using Helm.
+
+  ```
+  helm repo update && helm install --version 0.5.0 stable/cert-manager
+  ```
+  {: codeblock}
+
+
+## Installing the Helm chart
+{: #install-chart}
+
+Now that you've installed the prerequisites and created and configured your secrets, you're ready to install the service. You can use the provided Helm chart to install {{site.data.keyword.datashield_short}} on your SGX-enabled bare metal cluster.
+
+The Helm chart installs the following components:
+
+*	The supporting software for SGX.
+*	The {{site.data.keyword.datashield_short}} Enclave Manager, which manages SGX enclaves in the {{site.data.keyword.datashield_short}} environment.
+*	The container conversion service, which allows containerized applications to run in the {{site.data.keyword.datashield_short}} environment.
+
+
+1. Get the information that you need to set up [backup and restore](/docs/data-shield?topic=data-shield-backup-restore) capabilities.
+
+2. Install the chart.
+
+  ```
+  helm install iks-charts/ibmcloud-data-shield --set enclaveos-chart.Manager.AdminEmail=<admin email> --set enclaveos-chart.Manager.AdminName=<admin name> --set enclaveos-chart.Manager.AdminIBMAccountId=<hex account ID> --set global.IngressDomain=<your cluster's ingress domain>
+  ```
+  {: codeblock}
+
+  <table>
+    <caption>Table 1. Installation options</caption>
+    <tr>
+      <th>Command</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <td><code>--set converter-chart.Converter.DockerConfigSecret=converter-docker-config</code></td>
+      <td>Optional: If you [configured an {{site.data.keyword.cloud_notm}} Container Registry](/docs/data-shield?topic=data-shield-convert) you must append the Docker configuration to the installation command.</td>
+    </tr>
+    <tr>
+      <td><code>--set global.OpenShiftEnabled=true</code></td>
+      <td>Optional: If you are working with an {{site.data.keyword.openshiftshort}} cluster, be sure to append the {{site.data.keyword.openshiftshort}} tag to your installation command.</td>
+    </tr>
+    <tr>
+      <td><code>--set Manager.FailOnGroupOutOfDate=true</code></td>
+      <td>Optional: By default, node enrollment and the issueing of application certificates succeed. If you want the operations to fail if your platform microcode is out of date, append the flag to your install command. You are alerted in your dashboard when your service code is out of date. Note: It is not possible to change this option on existing clusters.</td>
+    </tr>
+    <tr>
+      <td><code>--set enclaveos-chart.Ias.Mode=IAS_API_KEY</code></td>
+      <td>Optional: You can use your own IAS API key. To do so, you must first obtain a linkable subscription for the Intel SGX Attestation Service. Then, generate a secret in your cluster by running the following command: <code>kubectl create secret generic ias-api-key --from-literal=env=<TEST/PROD> --from-literal=spid=<spid> --from-literal=api-key=<apikey></code>. Note: By default, IAS requests are made through a proxy service.</td>
+    </tr>
+  </table>
+
+3. To monitor the startup of your components, you can run the following command.
+
+  ```
+  kubectl get pods
+  ```
+  {: codeblock}
+
+  ## Installing {{site.data.keyword.datashield_short}} version 1.16 and upgrade to 1.17
+  {: #install-chart}
+Note:
+- If you are using IKS then `$install_args` =
+
+```
+iks-charts/ibmcloud-data-shield --set enclaveos-chart.Manager.AdminEmail=<admin email> --set global.Registry=<docker_registry> --set enclaveos-chart.Manager.AdminName=<admin name> --set enclaveos-chart.Manager.AdminIBMAccountId=<hex account ID> --set global.IngressDomain=<your cluster's ingress domain> --set converter-chart.Converter.DockerConfigSecret=converter-docker-config
+```
+{: codeblock}
+
+- If you are using OpenShift then ``$install_args` =
+
+```
+openshift-charts/ibmcloud-data-shield --set enclaveos-chart.Manager.AdminEmail=<admin email> --set global.Registry=<docker_registry> --set enclaveos-chart.Manager.AdminName=<admin name> --set enclaveos-chart.Manager.AdminIBMAccountId=<hex account ID> --set global.IngressDomain=<your cluster's ingress domain> --set converter-chart.Converter.DockerConfigSecret=converter-docker-config --set global.OpenShiftEnabled=true
+```
+{: codeblock}
+
+### Install {{site.data.keyword.datashield_short}} version 1.16 or below using helm2
+
+The IBM Cloud Data Shield Version 1.16 or below can only be installed using heml2, the commands are:
+
+```
+helm2 install --version 0.5.0 stable/cert-manager --name cert-manager
+helm2 install $install_args --name <release_name>
+
+```
+{: codeblock}
+
+### Upgrade {{site.data.keyword.datashield_short}} version 1.16 to 1.17 using heml2
+
+Once the user installs IBM Cloud Data Shield version 1.16, and when a new version of IBM Cloud Data Shield is available, the user can upgrade to the latest version with helm2 using the following commands:
+
+```
+Helm2 del --purge cert-manager
+kubectl delete crd certificates.certmanager.k8s.io issuers.certmanager.k8s.io clusterissuers.certmanager.k8s.io
+kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.10.1/deploy/manifests/00-crds.yaml
+kubectl create namespace cert-manager
+kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+helm2 repo add jetstack https://charts.jetstack.io
+helm2 repo update
+helm2 install --name cert-manager jetstack/cert-manager --namespace cert-manager --version v0.10.1 --set extraArgs[0]="--enable-certificate-owner-ref=true" --set webhook.enabled=false
+helm2 upgrade <release_name> $install_args --force
+```
+{: codeblock}
+
+The upgrade process also includes upgrading the `cert-manager`.
+
+### Migrate helm2 to helm3
+
+Now as an optional step, the user can migrate helm2 to helm3 after the upgrade completes. The commands are:
+Note: Migration from helm2 to helm3 can be done anytime after the installation or upgrade of IBM Cloud Data Shield 1.17 or above.
+
+```
+helm3 plugin install https://github.com/helm/helm-2to3
+helm3 2to3 move config
+helm3 2to3 convert cert-manager
+helm3 2to3 convert <release_name>
+```
+{: codeblock}
+
+To clean-up helm2 after migrating to helm3, the command is:
+
+```
+helm3 2to3 cleanup
+```
+{: codeblock}
+
+## Install {{site.data.keyword.datashield_short}} version 1.17 or above
+
+The user can do a fresh installation of IBM Cloud Data Shield version 1.17 using either helm2 or helm3. The commands for installation are:
+
+```
+kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.10.1/deploy/manifests/00-crds.yaml
+kubectl create namespace cert-manager
+kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+$helm repo add jetstack https://charts.jetstack.io
+$helm repo update
+```
+{: codeblock}
+
+Here `$helm` can be replaced with `$helm2` or `$helm3` depending on the user’s preference.
+
+### If helm version is helm2
+
+ If installation is being done using helm2 then use the following commands:
+
+ ```
+ $helm2 install --name cert-manager jetstack/cert-manager --namespace cert-manager --version v0.10.1 --set extraArgs[0]="--enable-certificate-owner-ref=true" --set webhook.enabled=false
+$helm2 install $install_args --name <release_name>
+ ```
+ {: codeblock}
+
+ ### If helm version is helm3
+
+ If installation is being done using helm3 then use the following commands:
+
+ ```
+ $helm3 install cert-manager jetstack/cert-manager --namespace cert-manager --version v0.10.1 --set extraArgs[0]="--enable-certificate-owner-ref=true" --set webhook.enabled=false
+ $helm3 install <release_name> $install_args
+ ```
+ {: codeblock}
+
+ ## Upgrade {{site.data.keyword.datashield_short}} to version greater than 1.17 or above
+
+ If the current IBM Cloud Data Shield version is 1.17 or greater, then the user can upgrade to a new version using helm2 or helm3 using the following commands:
+
+ ### If helm version is helm2
+
+ If upgrade is being done using helm2 then use the following commands:
+
+ ```
+$helm2 upgrade <release_name> $install_args --force
+ ```
+ {: codeblock}
+
+ ### If helm version is helm3
+
+ If upgrade is being done using helm3 then use the following commands:
+
+ ```
+ kubectl delete job $(kubectl get jobs -o custom-columns=:metadata.name | grep  cockroachdb-init)
+ $helm3 upgrade <release_name> $install_args
+ ```
+ {: codeblock}


### PR DESCRIPTION
Hi @smguilia , We recently documented "helm2 to helm3 migration for different versions of IBM Cloud Data Shield installation". I have added these sections in the "install.md" file. Also providing the content here as a pdf version. Please use the content to update your documentation accordingly.
[IBM CLOUD DATA SHIELD INSTALL AND UPGRADE USING HELM2 OR HELM3, V 1.0.pdf](https://github.com/ibm-cloud-docs/data-shield/files/4451919/IBM.CLOUD.DATA.SHIELD.INSTALL.AND.UPGRADE.USING.HELM2.OR.HELM3.V.1.0.pdf)
